### PR TITLE
Make ajax requests richer

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -287,7 +287,7 @@ class FrontControllerCore extends Controller
         $this->sslRedirection();
 
         if ($this->ajax) {
-            $this->display_header = false;
+            $this->display_header = true;
             $this->display_footer = false;
         }
 


### PR DESCRIPTION
On our way to build a cookies module for 1.7.x version, we try to get the page registered javascript,
but when on ajax mode (ajax=1) there is only the generic js list.
If some have been registered using the specific setMedia(), it does not show up.

This change overcomes this issue.

In case it breaks the rest of your layout etc, you can make it optional like ajax=1 you can make another like getAjaxJsList=1.

Kalimera :)

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | develop
| Description  | PS version 1.7.6.1 (but I do believe any 1.7.x is ok), default theme, default anything else.
| Type         | improvement / new feature
| Category     | FO
| BC breaks    | I am not sure but don't think so.
| Deprecations | Same as BC breaks, not guaranteed but I don't think so.
| How to test?  | In your last registered (and enabled) on 1.7.x version and displayHeader hook, paste the following snippet before the function return command.


    if (isset($params['ajax']) or Tools::getValue('ajax') == 1) {
        $files = $this->context->controller->getJavascript()['bottom']['external'];
        $result = Tools::jsonEncode(
            array(
                'files' => $files
            )
        );
        die($result);
    }